### PR TITLE
use uwsgi for serving requests when using docker

### DIFF
--- a/compass-api/Dockerfile
+++ b/compass-api/Dockerfile
@@ -1,8 +1,7 @@
 FROM python:3.5
 
-RUN apt-get update && apt-get install -y python3-psycopg2
+RUN apt-get update && apt-get install -y python3-psycopg2 libev-dev
 
-ENV WORKER_COUNT 2
 ENV USER py
 
 ADD ./wait-for-it/wait-for-it.sh /bin/wait-for-it.sh
@@ -12,7 +11,8 @@ RUN pip3 install -r /var/data/G4SE/dev-requirements.txt
 ADD ./G4SE /G4SE
 COPY ./docker-entrypoint.sh /bin/docker-entrypoint.sh
 COPY ./wait_only_docker-entrypoint.sh /bin/wait_only_docker-entrypoint.sh
+COPY ./uwsgi_docker.ini /uwsgi.ini
 
 ENTRYPOINT ["/bin/docker-entrypoint.sh"]
 
-CMD /usr/local/bin/gunicorn G4SE.wsgi:application -w ${WORKER_COUNT} --bind 0.0.0.0:8000
+CMD uwsgi /uwsgi.ini --processes ${NUM_PROCESSES:-2} --threads ${NUM_THREADS:-1}

--- a/compass-api/dev-requirements.txt
+++ b/compass-api/dev-requirements.txt
@@ -7,6 +7,7 @@
 beautifulsoup4==4.5.1
 brotlipy==0.5.1
 cffi==1.8.2               # via brotlipy
+contextlib2==0.5.4        # via raven
 coreapi==1.32.3           # via django-rest-swagger, openapi-codec
 django-cors-middleware==1.3.1
 django-debug-toolbar==1.5
@@ -29,6 +30,7 @@ pycparser==2.14           # via cffi
 pytest-django==3.0.0
 pytest==3.0.2             # via pytest-django
 python-dateutil==2.5.3    # via drf-haystack
+raven==5.31.0
 requests==2.11.1          # via coreapi
 schedule==0.3.2
 simplejson==3.8.2         # via django-rest-swagger
@@ -36,4 +38,5 @@ six==1.10.0               # via django-environ, django-extensions, python-dateut
 sqlparse==0.2.1           # via django-debug-toolbar
 uritemplate==3.0.0        # via coreapi
 urllib3==1.18             # via elasticsearch
+uwsgi==2.0.14
 whitenoise==3.2.1

--- a/compass-api/requirements.in
+++ b/compass-api/requirements.in
@@ -14,3 +14,4 @@ elasticsearch<2.0.0
 schedule
 beautifulsoup4
 raven
+uwsgi

--- a/compass-api/requirements.txt
+++ b/compass-api/requirements.txt
@@ -7,6 +7,7 @@
 beautifulsoup4==4.5.1
 brotlipy==0.5.1
 cffi==1.8.2               # via brotlipy
+contextlib2==0.5.4        # via raven
 coreapi==1.32.3           # via django-rest-swagger, openapi-codec
 django-cors-middleware==1.3.1
 django-environ==0.4.0
@@ -24,10 +25,12 @@ openapi-codec==1.0.0      # via django-rest-swagger
 psycopg2==2.6.2
 pycparser==2.14           # via cffi
 python-dateutil==2.5.3    # via drf-haystack
+raven==5.31.0
 requests==2.11.1          # via coreapi
 schedule==0.3.2
 simplejson==3.8.2         # via django-rest-swagger
 six==1.10.0               # via django-environ, python-dateutil
 uritemplate==3.0.0        # via coreapi
 urllib3==1.18             # via elasticsearch
+uwsgi==2.0.14
 whitenoise==3.2.1

--- a/compass-api/uwsgi_docker.ini
+++ b/compass-api/uwsgi_docker.ini
@@ -1,0 +1,4 @@
+[uwsgi]
+socket = 0.0.0.0:8000
+chdir = /G4SE/
+wsgi-file = G4SE/wsgi.py

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,7 +15,8 @@ services:
 #      You probably want to set these on the live-server
 #      - SENTRY_DSN=the dsn of sentry
 #      - SENTRY_RELEASE=staging/production or whatever
-#      - WORKER_COUNT=2 # a practice value, which is rough but not too way off: number of cores/cpus * 2 + 1
+      - NUM_PROCESSES=4  # uwsgi settings
+      - NUM_THREADS=2  # uwsgi settings
     links:
       - db:database
       - elasticsearch:elasticsearch

--- a/nginx/nginx.conf.template
+++ b/nginx/nginx.conf.template
@@ -70,13 +70,13 @@ server {
     location = /favicon.ico { access_log off; log_not_found off; }
 
     location /api {
-        proxy_pass http://api;
-        proxy_pass_request_headers on;
+        include uwsgi_params;
+        uwsgi_pass api;
     }
 
     location /admin {
-        proxy_pass http://api;
-        proxy_pass_request_headers on;
+        include uwsgi_params;
+        uwsgi_pass api;
     }
 
     location / {


### PR DESCRIPTION
only a tad faster, but using uwsgi should be generally more pleasant and more configurable than gunicorn.